### PR TITLE
Remove extra sentence in coordination section

### DIFF
--- a/charters/charter-2019.html
+++ b/charters/charter-2019.html
@@ -318,9 +318,6 @@
           <a href="https://www.w3.org/2011/webtv/">Interest Group's home
           page</a>.</p>
 
-
-        <p>Additional technical coordination around media topics with the following Groups will be made, per the :</p>
-
         <div>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>


### PR DESCRIPTION
I noticed that the final sentence under section 3 was missing the reference to the process document. As this is covered in the preceding paragraph, this sentence now seems unnecessary.