### PR TITLE
Outline of the IG Note on Web Media API Integration Guidelines

### DIFF
--- a/media-integration-guidelines/index.html
+++ b/media-integration-guidelines/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Web Media API Integration Guidelines</title>
+    <script
+     src='https://www.w3.org/Tools/respec/respec-w3c'
+     class='remove' async></script>
+    <script class='remove'>
+      var respecConfig = {
+        specStatus: "IG-NOTE",
+        charterDisclosureURI: "https://www.w3.org/2019/06/me-ig-charter.html#patentpolicy",
+        noRecTrack: true,
+        editors: [{
+          name: "John Riviello",
+          company: "Comcast",
+          companyURL: "http://comcastcorporation.com",
+          w3cid: 70923
+        }],
+        ig: "Media and Entertainment Interest Group",
+        igURI: "https://www.w3.org/2011/webtv/",
+        igPublicList: "public-web-and-tv",
+        igPatentURI:  "https://www.w3.org/2004/01/pp-impl/46300/status",
+        gitHub: "media-and-entertainment/media-integration-guidelines",
+        shortName: "media-integration-guidelines",
+        xref: "web-platform",
+      };
+    </script>
+  </head>
+  <body>
+    <section id='abstract'>
+      <p>
+        A number of issues seem to cause interoperability pain with web media apps related to the integration of web media APIs with hardware video & audio decoders.</p>
+      <p>This Interest Group Note seeks to document the actual experience and recommendations when dealing with web media APIs, specifically regarding video & audio decoders.</p>
+    </section>
+    <section id='sotd'></section>
+    <section>
+      <h2>Claiming Hardware Resources</h2>
+    </section>
+    <section>
+      <h2>Resource Contention</h2>
+    </section>
+    <section>
+      <h2>Timing</h2>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
As requested during the [April 7, 2020 MEIG call](https://www.w3.org/2020/04/07-me-minutes.html), I've put up a PR of the outline of the proposed Web Media API Integration Guidelines IG Note document. 

ReSpec required an editor, so I've put my name there for now. I'm happy to help edit, but I cannot do it alone, so anyone that is willing to be a co-editor with me is welcome to mention that 😃 

The initial discussion that drove this took place in https://github.com/w3c/webmediaporting/issues/30. To help focus the conversation until this PR is merged, I propose that:
- The discussions around the technical issues & answers continues in https://github.com/w3c/webmediaporting/issues/30 for now
- The discussion in this PR specifically will be to gather consensus on the title of the note and if it makes sense to host it here or in its own repo.

Once we have a title and location for this PR to be merged into, we can migrate the conversations to the same repo where this note will be worked on.