### PR TITLE
Update charter for 2021

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -279,11 +279,10 @@
             Group is working on the following documents:
           </p>
           <ul>
-            <li><a href="https://w3c.github.io/me-media-timed-events/">Media
-            Timed Events</a> &mdash; describes use cases, requirements, and
-            recommendations for improved support for timed events related to
-            audio or video media on the web. This document is being developed by
-            the Media Timed Events Task Force.</li>
+            <li><a href="https://github.com/w3c/me-media-integration-guidelines">Media Integration Guidelines</a>
+            &mdash; aims to document experience and recommendations for application developers
+            dealing with web media APIs, specifically regarding video and audio decoders,
+            across desktop, mobile, and TV devices.</li>
             <li><a href="https://w3c.github.io/me-vision/">A perspective on
             Media &amp; Entertainment for the Web</a> &mdash; provides an
             analysis of the Media &amp; Entertainment industry and identifies

--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -194,16 +194,13 @@
         </ul>
 
         <p>
-          Within the Media and Entertainment Interest Group, the
-          <a href="https://www.w3.org/2011/webtv/wiki/Main_Page/Media_Timed_Events_TF">Media
-          Timed Events Task Force</a> investigates use cases and technical
-          requirements for improved support for timed events related to audio or
-          video media on the web, where synchronization to a playing audio or
-          video media stream is needed, and makes recommendations for new or
-          changed web APIs to realize these requirements. The Interest Group may
-          create additional task forces to investigate specific topics and
-          develop a common understanding of architectural implications and
-          requirements the topic triggers.
+          The Media and Entertainment Interest Group is currently working on
+          <a href="https://github.com/w3c/me-media-integration-guidelines">Media Integration Guidelines</a>,
+          which aims to document experience and recommendations for application developers
+          dealing with web media APIs, specifically regarding video and audio decoders,
+          across desktop, mobile, and TV devices. Where interoperability issues are found,
+          this may result in issues being raised with the Media Working Group or WHATWG
+          as appropriate.
         </p>
 
         <section id="section-out-of-scope">


### PR DESCRIPTION
This PR updates the MEIG charter for 2021:

- Removed Media Timed Events TF, now in WICG
- Added Media Integration Guidelines

Review feedback welcome @JohnRiv @tidoust @ashimura @igarashi50 @palemieux 