### PR TITLE
Charter: Update reference to MPEG, adjust change history

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -489,10 +489,11 @@ groups are likely to be important: </p>
                 multimedia framework for IPTV services (LIME) gives a subset of HTML, CSS
                 and ECMAScript for use in IPTV terminals.</dd>
 
-            <dt><a href="https://mpeg.chiariglione.org/">MPEG</a></dt>
-            <dd>The Moving Picture Experts Group is a working group of ISO/IEC in
-                charge of the development of standards for coded representation of
-                digital audio, video and related data.</dd>
+            <dt><a href="https://www.iso.org/committee/45316.html">ISO/IEC JTC 1/SC 29</a></dt>
+            <dd>The ISO/IEC JTC 1/SC 29 committee (formerly known as
+              <abbr title="Moving Picture Experts Group">MPEG</abbr>) develops
+              standards for coded representation of digital audio, picture,
+              video, multimedia and hypermedia information.</dd>
 
             <dt><a href="https://www.oasis-open.org/home/index.php">OASIS</a></dt>
             <dd>Organization for the Advancement of Structured Information Standards is
@@ -801,6 +802,9 @@ groups are likely to be important: </p>
                 <td>
                   <ul>
                     <li>Wording adjusted to match latest version of charter template</li>
+                    <li>Removed Media Timed Events Task Force</li>
+                    <li>Added Media Integration Guidelines</li>
+                    <li>List of groups and organizations refreshed</li>
                   </ul>
                 </td>
               </tr>


### PR DESCRIPTION
MPEG no longer exists as a separate organization, updating the entry to point to the ISO committee page instead. Text adjusted to align with that page.

This update also completes the change history to mention previous updates.

Linked to #43.