### PR TITLE
Charter: Separate Success criteria and tasks from scope

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -53,6 +53,7 @@
       <aside>
         <ul id="navbar">
           <li><a href="#scope">Scope</a></li>
+          <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
@@ -172,7 +173,39 @@
           <li>accessibility of media experiences and standards</li>
         </ul>
 
-        <p>The tasks that the Interest Group will undertake include: </p>
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+          <p>The technical development of standards is not in scope for the
+          Interest Group. Technical discussions are expected to take place
+          within the appropriate W3C groups if such a group exists, or within a
+          dedicated Community Group or Business Group when incubation is needed.</p>
+        </section>
+      </section>
+
+      <section id='success-criteria'>
+        <h2>Success Criteria</h2>
+        <p>The Interest Group will have succeeded if it can achieve the following:</p>
+        <ul>
+          <li>Participation via mailing list subscription and postings from people
+            representing various stakeholder communities, including media professionals, broadcasters,
+            hardware and software developers, telecom companies, cable operators,
+            application developers, regulators, and users</li>
+          <li>Members of the Interest Group join relevant Working Groups and drive the
+            development of work items</li>
+          <li>Members of the Interest Group start or join related Community/Business Groups and
+            contribute to creating Interest Group Notes</li>
+          <li>Constructive feedback on W3C deliverables posted for review on the
+            <a href="https://lists.w3.org/Archives/Public/public-web-and-tv/">Media and
+            Entertainment IG mailing list</a></li>
+          <li>Engagement and coordination with other organizations in the media
+            industry to promote adherence to W3C standards</li>
+        </ul>
+
+        <p>To achieve this, the Interest Group will organize regular
+        conference calls to update members on progress of work items, and to
+        invite other groups and organizations to present their work to
+        Interest Group participants. The group will also undertake a number of
+        tasks, including:</p>
         <ul>
           <li>Identification of requirements for tighter support of
             media-centric applications on the Web platform, possibly through
@@ -192,52 +225,7 @@
           internationalization, performance, privacy, and security are given
           equal consideration in all discussions and outcomes.</li>
         </ul>
-
-        <p>
-          The Media and Entertainment Interest Group is currently working on
-          <a href="https://github.com/w3c/me-media-integration-guidelines">Media Integration Guidelines</a>,
-          which aims to document experience and recommendations for application developers
-          dealing with web media APIs, specifically regarding video and audio decoders,
-          across desktop, mobile, and TV devices. Where interoperability issues are found,
-          this may result in issues being raised with the Media Working Group or WHATWG
-          as appropriate.
-        </p>
-
-        <section id="section-out-of-scope">
-          <h3 id="out-of-scope">Out of Scope</h3>
-          <p>The technical development of standards is not in scope for the
-          Interest Group. Technical discussions are expected to take place
-          within the appropriate W3C groups if such a group exists, or within a
-          dedicated Community Group or Business Group when incubation is needed.</p>
-        </section>
-
-        <section id='success-criteria'>
-          <h3>Success Criteria</h3>
-          <p>We will have succeeded if we can achieve the following:</p>
-          <ul>
-            <li>Participation via mailing list subscription and postings from people
-              representing various stakeholder communities, including media professionals, broadcasters,
-              hardware and software developers, telecom companies, cable operators,
-              application developers, regulators, and users</li>
-            <li>Members of the Interest Group join relevant Working Groups and drive the
-              development of work items</li>
-            <li>Members of the Interest Group start or join related Community/Business Groups and
-              contribute to creating Interest Group Notes</li>
-            <li>Constructive feedback on W3C deliverables posted for review on the
-              <a href="https://lists.w3.org/Archives/Public/public-web-and-tv/">Media and
-              Entertainment IG mailing list</a></li>
-            <li>Engagement and coordination with other organizations in the media
-              industry to promote adherence to W3C standards</li>
-          </ul>
-
-          <p>To achieve this, the Interest Group will organize regular
-          conference calls to update members on progress of work items, and to
-          invite other groups and organizations to present their work to
-          Interest Group participants.</p>
-        </section>
       </section>
-
-
 
       <section id="deliverables">
         <h2>
@@ -282,7 +270,9 @@
             <li><a href="https://github.com/w3c/me-media-integration-guidelines">Media Integration Guidelines</a>
             &mdash; aims to document experience and recommendations for application developers
             dealing with web media APIs, specifically regarding video and audio decoders,
-            across desktop, mobile, and TV devices.</li>
+            across desktop, mobile, and TV devices. Where interoperability issues are found,
+            this may result in issues being raised with the Media Working Group or WHATWG
+            as appropriate.</li>
             <li><a href="https://w3c.github.io/me-vision/">A perspective on
             Media &amp; Entertainment for the Web</a> &mdash; provides an
             analysis of the Media &amp; Entertainment industry and identifies
@@ -801,6 +791,7 @@ groups are likely to be important: </p>
                 <td>
                   <ul>
                     <li>Wording adjusted to match latest version of charter template</li>
+                    <li>Success criteria and tasks separated from scope</li>
                   </ul>
                 </td>
               </tr>


### PR DESCRIPTION
This update moves the Success criteria section out of the Scope section, as done in the [charter template](https://w3c.github.io/charter-drafts/charter-template.html).

It also moves the list of tasks that the group will undertake to that section to clarify how success criteria will be met [as suggested by @palemieux during last IG call](https://www.w3.org/2021/03/02-me-minutes.html#t03).

As opposed to the charter template, the Success Criteria section appears *before* the Deliverables section, because it seems more important in the context of an IG that does not have a specific list of deliverables.

Note that the paragraph that talked about the current work on Media Integration Guidelines is now gone. I completed the description of the deliverable to mention possible issues to be raised with the Media WG or WHATWG.

Linked to #43.