### PR TITLE
Get back to boilerplate text for Coordination section

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -258,7 +258,6 @@
           </p>
           <ul>
             <li>Use case and requirement documents;</li>
-            <li>Test suite and implementation report for the specification;</li>
             <li>Primer or Best Practice documents to support web developers when designing applications.</li>
           </ul>
           <p>
@@ -290,9 +289,11 @@
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all topics discussed within the group, this
+        <p>For all specifications, this
           Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
-          For non-normative specifications that the Interest Group may develop, invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Interest Group is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+          Invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.
+          The Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout the development of each specification.
+          The Interest Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
         <p>The scope of the Media and Entertainment Interest Group includes
           tracking and review of media-related deliverables developed by other


### PR DESCRIPTION
Previous text was an attempt to adjust the boilerplate text to account for the fact that the IG won't publish any document in CR and, most of the time, will not even publish an IG Note.

However, that text was clumsy, as pointed out in https://github.com/w3c/media-and-entertainment/issues/52

This update brings the text back to what it is in the charter template. The bits on CR do not really apply to the IG, but then the group could perhaps one day decide to publish non normative best practices that could go to Rec, so it seems a good idea to keep the text around.