### PR TITLE
Re-introduce horizontal review text, adjusted to IG Notes

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -280,7 +280,12 @@
 
       <section id="coordination">
         <h2>Coordination</h2>
-           <p>The scope of the Media and Entertainment Interest Group includes
+          <p>For all deliverables, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a> and <a href="https://www.w3.org/Consortium/Process/#WGNote">IG Note</a>.
+          The Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout the development of each deliverable.
+          The Interest Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#WGNote">IG Note</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+          <p>The scope of the Media and Entertainment Interest Group includes
           tracking and review of media-related deliverables developed by other
           W3C groups, as well as coordination with other organizations in the
           media industry. As such, the Media and Entertainment Interest Group intends to


### PR DESCRIPTION
Follow-up from previous pull request from @wseltzer that dropped the text entirely:
https://github.com/w3c/media-and-entertainment/pull/62

The idea here is to rather preserve the text as approved by horizontal reviewers, adjusting it to fit the type of deliverables that the IG may produce.