### PR TITLE
[Charter] Add Publishing@W3C groups to coordination section

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -308,11 +308,17 @@
             <dt><a href="https://www.w3.org/2011/audio/">Audio WG</a></dt>
             <dd>The Audio Working Group develops the <a href="https://www.w3.org/TR/webaudio/">Web Audio API</a> specification for processing and synthesizing audio in web applications.</dd>
 
+            <dt><a href="https://www.w3.org/publishing/groups/publ-wg/">Audiobooks WG</a></dt>
+            <dd>The Audiobooks Working Group maintains the Publication Manifest and Audiobooks Recommendations and related Working Group Notes.</dd>
+
             <dt><a href="https://www.w3.org/auto/wg/">Automotive WG</a> and <a href="https://www.w3.org/community/autowebplatform/">Automotive and Platform Business Group</a></dt>
             <dd>Both groups develop specifications and use cases for media players embedded in in-vehicle infotainment systems.</dd>
 
             <dt><a href="https://www.w3.org/Style/CSS/members">CSS WG</a></dt>
             <dd>The CSS Working Group develops specifications that are of particular interest to media companies such as efforts to bring High Dynamic Range (HDR) content and Wide-gamut colors to the web.</dd>
+
+            <dt><a href="https://www.w3.org//publishing/groups/epub-wg/">EPUB 3 WG</a></dt>
+            <dd>The EPUB 3 Working Group maintains and develops the EPUB 3 family of specifications, which includes the EPUB Media Overlays specification for representation of audio synchronized with the EPUB Content Document.</dd>
 
             <dt><a href="https://www.w3.org/2020/gpu/">GPU for the Web WG</a></dt>
             <dd>The GPU for the Web Working Group develops specifications that provide an interface between the Web Platform and modern 3D graphics and computation capabilities present on native system platforms. Scope includes capabilities for rendering media as textures.</dd>
@@ -342,7 +348,7 @@
             <dd>The WebTransport Working Group develops APIs that enable data transfer between browsers and servers with support for multiple data flows, unidirectional data flows, out-of-order delivery, variable reliability and pluggable protocols. Those specifications could be useful to transfer media and control them.</dd>
 
 <!-- IGs -->
-            <dt><a href="https://www.w3.org/groups/ig/web-networks">Web & Networks Interest Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/ig/web-networks">Web & Networks IG</a></dt>
             <dd>The Web & Networks Interest Group explores solutions for web applications to leverage network capabilities in order to achieve better performance and resource allocation, both on the device and network.</dd>
 
 <!-- CGs -->
@@ -370,8 +376,14 @@
             <dt><a href="https://www.w3.org/community/webtiming/">Multi-device Timing CG</a></dt>
             <dd>Support multi-device timing in media applications, such as multi-screen presentations</dd>
 
+            <dt><a href="https://www.w3.org/community/publishingcg/">Publishing CG</a> and <a href="https://www.w3.org/community/publishingbg/">Publishing BG</a></dt>
+            <dd>The Publishing Community Group functions as an incubator group to explore, test, and possibly specify new ideas that may be included, eventually, into later versions of EPUB 3.X. The Publishing Business Group fosters ongoing participation by members of the publishing industry and overall publishing ecosystem in the development of the Web for publishing, and serves as a conduit for feedback between the publishing ecosystem and W3C.</dd>
+
             <dt><a href="https://www.w3.org/community/webscreens/">Second Screen CG</a></dt>
             <dd>The Second Screen Community Group, companion group of the Second Screen Working Group, discusses the development of an Open Screen Protocol to improve the interoperability between first and second screens.</dd>
+
+            <dt><a href="https://www.w3.org/community/sync-media-pub/">Synchronized Multimedia for Publications CG</a></dt>
+            <dd>The Synchronized Multimedia for Publications Community Group plans to produce a simplified version of audio and video synchronization that may become part of a future EPUB version.</dd>
 
             <dt><a href="https://www.w3.org/community/wicg/">Web Platform Incubator CG</a></dt>
             <dd>The Web Platform Incubator Community Group incubates a number of proposals from the community, including media-relevant ideas such as <a href="https://github.com/WICG/canvas-color-space">Canvas Color Spaces</a>, <a href="https://wicg.github.io/video-rvfc/">HTMLMediaElement.requestVideoFrameCallback()</a>, and <a href="https://wicg.github.io/media-feeds/">Media Feeds</a>.</dd>


### PR DESCRIPTION
This adds the Audiobooks WG, the EPUB 3 WG, the Publishing CG/BG and the Synchronized Multimedia for Publications CG, from the publishing activity to the coordination section, as suggested during the AC review of the charter.