### PR TITLE
[charter] Highlight Publishing BG as focal point

### DIFF
--- a/charters/charter-2021.html
+++ b/charters/charter-2021.html
@@ -347,7 +347,10 @@
             <dt><a href="https://www.w3.org/groups/wg/webtransport">WebTransport WG</a></dt>
             <dd>The WebTransport Working Group develops APIs that enable data transfer between browsers and servers with support for multiple data flows, unidirectional data flows, out-of-order delivery, variable reliability and pluggable protocols. Those specifications could be useful to transfer media and control them.</dd>
 
-<!-- IGs -->
+<!-- BGs/IGs -->
+            <dt><a href="https://www.w3.org/community/publishingbg/">Publishing BG</a></dt>
+            <dd>The Publishing Business Group is the focal point for the publishing activity in W3C, fostering ongoing participation by members of the publishing industry and overall publishing ecosystem in the development of the Web for publishing, and serving as a conduit for feedback between the publishing ecosystem and W3C.</dd>
+
             <dt><a href="https://www.w3.org/groups/ig/web-networks">Web & Networks IG</a></dt>
             <dd>The Web & Networks Interest Group explores solutions for web applications to leverage network capabilities in order to achieve better performance and resource allocation, both on the device and network.</dd>
 
@@ -376,8 +379,8 @@
             <dt><a href="https://www.w3.org/community/webtiming/">Multi-device Timing CG</a></dt>
             <dd>Support multi-device timing in media applications, such as multi-screen presentations</dd>
 
-            <dt><a href="https://www.w3.org/community/publishingcg/">Publishing CG</a> and <a href="https://www.w3.org/community/publishingbg/">Publishing BG</a></dt>
-            <dd>The Publishing Community Group functions as an incubator group to explore, test, and possibly specify new ideas that may be included, eventually, into later versions of EPUB 3.X. The Publishing Business Group fosters ongoing participation by members of the publishing industry and overall publishing ecosystem in the development of the Web for publishing, and serves as a conduit for feedback between the publishing ecosystem and W3C.</dd>
+            <dt><a href="https://www.w3.org/community/publishingcg/">Publishing CG</a></dt>
+            <dd>The Publishing Community Group functions as an incubator group to explore, test, and possibly specify new ideas that may be included, eventually, into later versions of EPUB 3.X.</dd>
 
             <dt><a href="https://www.w3.org/community/webscreens/">Second Screen CG</a></dt>
             <dd>The Second Screen Community Group, companion group of the Second Screen Working Group, discusses the development of an Open Screen Protocol to improve the interoperability between first and second screens.</dd>


### PR DESCRIPTION
This adjusts previous wording around the publishing activity in the coordination section per feedback.