### PR TITLE
use the latest charter-template.html on the charter-drafts repo

### DIFF
--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -55,7 +55,7 @@
           <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
-		  <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
@@ -104,7 +104,7 @@
             <td>
               <i class="todo">See the <a href="https://www.w3.org/groups/wg/me/charters">group status page</A> and <a href="#history">detailed change history</a>.</i>
             </td>
-          </tr>		
+          </tr>
           <tr id="Duration">
             <th>
               Start date
@@ -151,8 +151,6 @@
             </td>
           </tr>
         </table>
-
-        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
       </div>
 
       <div id="background" class="background">
@@ -305,10 +303,6 @@
 
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
-
-          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
-          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
-            Instead, put it in the scope section.</p>
 
 <!-- WGs -->
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) WG</a></dt>

--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -46,24 +46,16 @@
       footer {
         font-size: small;
       }
-
-      .info {
-        background-color: #ddd;
-        margin-top: 1em;
-        padding-left: 15px;
-        padding-right: 15px;
-        border: 1px solid transparent;
-        border-radius: 4px;
-      }
     </style>
   </head>
   <body>
     <header id="header">
       <aside>
         <ul id="navbar">
+          <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
-          <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
+		  <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
@@ -81,50 +73,44 @@
 
     <main>
       <h1 id="title"><i class="todo">PROPOSED</i> Media and Entertainment Interest Group Charter</h1>
-
-      <div class="info">
-        <p>
-          This proposed charter should now be considered obsolete. Please see
-          the <a href="https://www.w3.org/2021/06/me-ig-charter.html">approved
-          charter</a>.
-        </p>
-      </div>
-
-      <div class="info">
-        <p>
-          This document is a draft charter proposed for discussion and review
-          by the W3C Advisory Committee. It is available on
-          <a href="https://github.com/w3c/media-and-entertainment/blob/master/charters/charter-2023.html">GitHub</a>.
-          Feel free to raise <a href="https://github.com/w3c/media-and-entertainment/issues">issues</a>.</p>
-      </div>
+      <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the <a
-        href="/2011/webtv/">Media and Entertainment Interest Group</a>
-        is to provide a forum for media-related technical discussions to
-        track progress of media features on the Web within W3C groups and
-        use of Web technologies by external organizations, and to identify use
-        cases and requirements that existing and/or new specifications need to
-        meet to achieve a tighter support of media services on the Web.
+          href="/2011/webtv/">Media and Entertainment Interest Group</a>
+          is to provide a forum for media-related technical discussions to
+          track progress of media features on the Web within W3C groups and
+          use of Web technologies by external organizations, and to identify use
+          cases and requirements that existing and/or new specifications need to
+          meet to achieve a tighter support of media services on the Web.
       </p>
+      <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
       <div class="noprint">
         <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/46300/join">Join the Media and Entertainment Interest Group</a>.</p>
       </div>
 
-      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
       on <i class="todo"><a href="https://github.com/w3c/media-and-entertainment">GitHub</a>.
 
     Feel free to raise <a href="https://github.com/w3c/media-and-entertainment/issues">issues</a></i>.
           </p>
 
-      <section id="details">
+      <div id="details">
         <table class="summary-table">
+          <tr id="Status">
+            <th>
+              Charter Status
+            </th>
+            <td>
+              <i class="todo">See the <a href="https://www.w3.org/groups/wg/me/charters">group status page</A> and <a href="#history">detailed change history</a>.</i>
+            </td>
+          </tr>		
           <tr id="Duration">
             <th>
               Start date
             </th>
             <td>
-              <i class="todo">When approved</i>
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -132,22 +118,15 @@
               End date
             </th>
             <td>
-              <i class="todo">Start date + 2 years</i>
+              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
             </td>
           </tr>
-
-          <tr>
-            <th>Charter extension</th>
-            <td>See <a href="#history">Change History</a>.
-            </td>
-          </tr>
-
           <tr>
             <th>
               Chairs
             </th>
             <td>
-                Tatsuya Igarashi (Sony), Chris Needham (BBC), Christopher Lorenzo (Comcast)
+              Tatsuya Igarashi (Sony), Chris Needham (BBC), Christopher Lorenzo (Comcast)
             </td>
           </tr>
           <tr>
@@ -164,18 +143,22 @@
             </th>
             <td>
               <strong>Teleconferences:</strong> A regular teleconference will be held, at least quarterly, with additional calls as
-                required. Task Forces may have separate calls that will not
-                overlap with
-                others.
+              required. Task Forces may have separate calls that will not
+              overlap with
+              others.
               <br />
               <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 1 per year.
             </td>
           </tr>
         </table>
 
-      </section>
+        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
+      </div>
 
-
+      <div id="background" class="background">
+        <h2>Motivation and Background</h2>
+        <p><i class="todo">Background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
+      </div>
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
@@ -200,14 +183,56 @@
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
           <p>The technical development of standards is not in scope for the
-          Interest Group. Technical discussions are expected to take place
-          within the appropriate W3C groups if such a group exists, or within a
-          dedicated Community Group or Business Group when incubation is needed.</p>
+              Interest Group. Technical discussions are expected to take place
+              within the appropriate W3C groups if such a group exists, or within a
+              dedicated Community Group or Business Group when incubation is needed.</p>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <p>
+            The primary deliverables of the Media and Entertainment Interest Group are IG Notes
+            that identify requirements for existing and/or new technical
+            specifications and gaps in the Web Platform.
+        </p>
+
+        <p>Updated document status is available on the <a href="https://www.w3.org/groups/ig/me/publications">group publication status page</a>.</p>
+
+        <section id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <p>
+              The Interest Group will not deliver any normative specifications.
+          </p>
+        </section>
+
+        <section id="ig-other-deliverables">
+          <h3>
+            Other Deliverables
+          </h3>
+          <p>
+              Other non-normative documents may be created such as:
+          </p>
+          <ul>
+              <li>Use case and requirement documents</li>
+              <li>Primer or best practice documents to support web developers when designing applications</li>
+          </ul>
+        </section>
+
+        <section id="timeline">
+          <h3>Timeline</h3>
+          <p>The IG will, during its lifetime, undertake different activities that may proceed in parallel. No specific timeline has been identified at this point, but the various activities are intended to be running for short periods of time (2-12 months), with the possibility of running a few iterations of them.</p>
         </section>
       </section>
 
-      <section id='success-criteria'>
-        <h2>Success Criteria</h2>
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
         <p>The Interest Group will have succeeded if it can achieve outcomes including:</p>
         <ul>
           <li>Participation via mailing list or GitHub issues from people
@@ -249,71 +274,41 @@
           internationalization, performance, privacy, and security are all given
           due consideration in all discussions and outcomes</li>
         </ul>
-      </section>
 
-      <section id="deliverables">
-        <h2>
-          Deliverables
-        </h2>
-        <p>
-          The primary deliverables of the Media and Entertainment Interest Group are IG Notes
-          that identify requirements for existing and/or new technical
-          specifications and gaps in the Web Platform.
-        </p>
-
-        <section id="normative">
-          <h3>
-            Normative Specifications
-          </h3>
-          <p>
-            The Interest Group will not deliver any normative specifications.
-          </p>
-        </section>
-
-        <section id="ig-other-deliverables">
-          <h3>
-            Other Deliverables
-          </h3>
-          <p>
-            Other non-normative documents may be created such as:
-          </p>
-          <ul>
-            <li>Use case and requirement documents</li>
-            <li>Primer or best practice documents to support web developers when designing applications</li>
-          </ul>
-        </section>
-
-        <section id="timeline">
-          <h3>Timeline</h3>
-          <p>The IG will, during its lifetime, undertake different activities that may proceed in parallel. No specific timeline has been identified at this point, but the various activities are intended to be running for short periods of time (2-12 months), with the possibility of running a few iterations of them.</p>
-        </section>
-      </section>
-
-
+    <!-- Design principles -->
+    <p>This Interest Group expects to follow the
+    TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.
+    </p>
+	</section>
 
       <section id="coordination">
         <h2>Coordination</h2>
-          <p>For all deliverables, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
-          Invitation for review must be issued during each major document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a> and <a href="https://www.w3.org/Consortium/Process/#WGNote">IG Note</a>.
-          The Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout the development of each deliverable.
-          The Interest Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#WGNote">IG Note</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+        <p>For all deliverables, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+        Invitation for review must be issued during each major document transition, including <a href="https://www.w3.org/Consortium/Process/#WGNote">IG Note</a>.
+        The Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout the development of each deliverable.
+        The Interest Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#WGNote">IG Note</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
-          <p>The scope of the Media and Entertainment Interest Group includes
-          tracking and review of media-related deliverables developed by other
-          W3C groups, as well as coordination with other organizations in the
-          media industry. As such, the Media and Entertainment Interest Group intends to
-          coordinate around media topics with other groups and organizations as
-          needed, per the
-          <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C
-          Process Document</a>. As of the day of chartering, the following
-          groups and organizations have been identified. Changes to these lists
-          will be documented on the
-          <a href="https://www.w3.org/2011/webtv/">Interest Group's home
-          page</a>.</p>
+        <p>The scope of the Media and Entertainment Interest Group includes
+            tracking and review of media-related deliverables developed by other
+            W3C groups, as well as coordination with other organizations in the
+            media industry. As such, the Media and Entertainment Interest Group intends to
+            coordinate around media topics with other groups and organizations as
+            needed, per the
+            <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C
+                Process Document</a>. As of the day of chartering, the following
+            groups and organizations have been identified. Changes to these lists
+            will be documented on the
+            <a href="https://www.w3.org/2011/webtv/">Interest Group's home
+                page</a>.</p>
 
-        <div>
+      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+
+        <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
-          <dl>
+
+          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
+          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
+            Instead, put it in the scope section.</p>
 
 <!-- WGs -->
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) WG</a></dt>
@@ -399,7 +394,9 @@
             <dt><a href="https://www.w3.org/community/webmediaapi/">Web Media API CG</a></dt>
             <dd>The Web Media API Community Group incubates a minimum set of web technologies that developers of media web applications can rely on being supported across devices. The group was proposed by and continues to cooperate with the <a href="https://cta.tech/WAVE">CTA WAVE Project</a>.</dd>
           </dl>
+        </section>
 
+        <section>
           <h3 id="external-coordination">External Organizations</h3>
           <p>There are a number of external groups working in areas related to the ones
 in scope for the Media and Entertainment IG. The Interest Group should determine whom to
@@ -528,17 +525,15 @@ groups are likely to be important: </p>
 
           <p>(This is not intended as an exhaustive list, but illustrative of groups
           working on related technologies)</p>
-        </div>
+        </section>
       </section>
-
-
 
       <section class="participation">
         <h2 id="participation">
           Participation
         </h2>
         <p>
-          To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from key media industries, and active Task Force leaders. The Chairs and Task Force leaders are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.
+          To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
@@ -546,9 +541,8 @@ groups are likely to be important: </p>
         <p>
           The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
         </p>
-        <p>
-          Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.
-        </p>
+        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
       </section>
 
 
@@ -558,16 +552,18 @@ groups are likely to be important: </p>
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however.
+          Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+        The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/2011/webtv/">Interest Group home page</a>.
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group home page.</a>
         </p>
         <p>
-          Most Interest Group teleconferences will focus on discussion of particular areas tracked or investigated by the group, and will be conducted on an as-needed basis.
+          Most Media and Entertainment Interest Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work on <a id="public-github" href="https://github.com/w3c/media-and-entertainment/issues">GitHub issues</a>.
+          This group primarily conducts its technical work
+          on " id="public-github" href="[ttps://github.com/w3c/media-and-entertainment/issues">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
@@ -582,7 +578,7 @@ groups are likely to be important: </p>
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
            However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
         </p>
@@ -597,7 +593,7 @@ groups are likely to be important: </p>
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
         </p>
         <p>
-          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 3.4, Votes)</a> and includes no voting procedures beyond what the Process Document requires.
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
         </p>
       </section>
 
@@ -613,8 +609,7 @@ groups are likely to be important: </p>
           produce Recommendation-track documents, when Interest Group
           participants review Recommendation-track specifications from Working
           Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
-          please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C
-            Patent Policy Implementation</a>.</p>
+          please see the <a href="https://www.w3.org/groups/ig/[shortname]/ipr">licensing information</a>.</p>
       </section>
 
 
@@ -631,7 +626,7 @@ groups are likely to be important: </p>
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
         <section id="history">
@@ -661,7 +656,8 @@ groups are likely to be important: </p>
             Group</a>.
           </p>
 
-          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
           <table class="history">
             <tbody>
@@ -848,6 +844,19 @@ groups are likely to be important: </p>
             </tbody>
           </table>
         </section>
+
+        <section id="changelog">
+          <h3>Change log</h3>
+
+          <!-- Use this section for changes _after_ the charter was approved by the Director. -->
+          <p>Changes to this document are documented in this section.</p>
+          <!--
+          <dl id='changes'>
+            <dt>YYYY-MM-DD</dt>
+            <dd>[changes]]</dd>
+          </dl>
+          -->
+        </section>
       </section>
     </main>
 
@@ -858,19 +867,11 @@ groups are likely to be important: </p>
         <a href="mailto:ashimura@w3.org">Kazuyuki Ashimura</a>
       </address>
 
-      <p class="copyright">
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2021
-        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (
-        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="https://www.keio.ac.jp/">Keio</a>,
-        <a href="https://ev.buaa.edu.cn/">Beihang</a>
-        ), All Rights Reserved.
-
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
-      </p>
+<p class="copyright">Copyright © <i class="todo">[yyyy]</i> <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
     </footer>
 
   </body>

--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -527,7 +527,7 @@ groups are likely to be important: </p>
           Participation
         </h2>
         <p>
-          To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.
+          To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from key media industries, and active Task Force leaders. The Chairs and Task Force leaders are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.

--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -52,7 +52,6 @@
     <header id="header">
       <aside>
         <ul id="navbar">
-          <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
           <li><a href="#success-criteria">Success Criteria</a></li>
@@ -151,11 +150,6 @@
             </td>
           </tr>
         </table>
-      </div>
-
-      <div id="background" class="background">
-        <h2>Motivation and Background</h2>
-        <p><i class="todo">Background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
       </div>
 
       <section id="scope" class="scope">

--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -81,7 +81,7 @@
           track progress of media features on the Web within W3C groups and
           use of Web technologies by external organizations, and to identify use
           cases and requirements that existing and/or new specifications need to
-          meet to achieve a tighter support of media services on the Web.
+          meet to achieve improved support for media services on the Web.
       </p>
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 

--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -553,7 +553,7 @@ groups are likely to be important: </p>
           Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group home page.</a>
         </p>
         <p>
-          Most Media and Entertainment Interest Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most Media and Entertainment Interest Group teleconferences will focus on discussion of particular areas tracked or investigated by the group, and will be conducted on an as-needed basis.
         </p>
         <p>
           This group primarily conducts its technical work


### PR DESCRIPTION
As the title says, put all the contents into to the latest Charter template at:
  https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html

* [Rendered version template](https://w3c.github.io/charter-drafts/charter-template.html)
* [Rendered version of the Draft Charter](https://cdn.statically.io/gh/w3c/media-and-entertainment/use-latest-template/charters/charter-2023.html)
* [HTML Diff from the previous Draft](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fmedia-and-entertainment%2Fcharters%2Fcharter-2023.html&doc2=https%3A%2F%2Fcdn.statically.io%2Fgh%2Fw3c%2Fmedia-and-entertainment%2Fuse-latest-template%2Fcharters%2Fcharter-2023.html)