### PR TITLE
Update charter-2023.html - remove unnecessary two items from the history table

### DIFF
--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -853,8 +853,6 @@ groups are likely to be important: </p>
                 </td>
                 <td>
                   <ul>
-                    <li>Wording adjusted to match the latest version of charter template</li>
-                    <li>Deliverables section also moved to the second section to match the latest template</li>
                     <li>Collaboration on the Media Accessibility User Requirements (MAUR) has been explicitly added within the Collaboration with the APA WG</li>
                     <li>Newly created Audiovisual Media Formats for Browser CG has been added to the Collaboration section</li>
                   </ul>


### PR DESCRIPTION
removing:
* Wording adjusted to match the latest version of charter template
* Deliverables section also moved to the second section to match the latest template
from the history table for this version based on the comments from the TiLT Team.