### PR TITLE
Refreshed links to Groups. Web Platform WG is now Web Applications Wo…

### DIFF
--- a/charters/charter-2023.html
+++ b/charters/charter-2023.html
@@ -75,7 +75,7 @@
       <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the <a
-          href="/2011/webtv/">Media and Entertainment Interest Group</a>
+          href="https://www.w3.org/groups/ig/me/">Media and Entertainment Interest Group</a>
           is to provide a forum for media-related technical discussions to
           track progress of media features on the Web within W3C groups and
           use of Web technologies by external organizations, and to identify use
@@ -85,7 +85,7 @@
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/46300/join">Join the Media and Entertainment Interest Group</a>.</p>
+        <p class="join"><a href="https://www.w3.org/groups/ig/me/join/">Join the Media and Entertainment Interest Group</a>.</p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -300,13 +300,13 @@
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) WG</a></dt>
             <dd>The APA Working Group conducts horizontal reviews of accessibility requirements and develops accessibility user requirements for media that are of particular interest for a number of topics investigated by the Media and Entertainment Interest Group. The Interest Group expects to collaborate with the APA Working Group on updates to the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements (MAUR)</a>.</dd>
 
-            <dt><a href="https://www.w3.org/2011/audio/">Audio WG</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/audio/">Audio WG</a></dt>
             <dd>The Audio Working Group develops the <a href="https://www.w3.org/TR/webaudio/">Web Audio API</a> specification for processing and synthesizing audio in web applications.</dd>
 
             <dt><a href="https://www.w3.org/auto/wg/">Automotive WG</a> and <a href="https://www.w3.org/community/autowebplatform/">Automotive and Platform Business Group</a></dt>
             <dd>Both groups develop specifications and use cases for media players embedded in in-vehicle infotainment systems.</dd>
 
-            <dt><a href="https://www.w3.org/Style/CSS/members">CSS WG</a></dt>
+            <dt><a href="https://www.w3.org/Style/CSS/">CSS WG</a></dt>
             <dd>The CSS Working Group develops specifications that are of particular interest to media companies such as efforts to bring High Dynamic Range (HDR) content and Wide-gamut colors to the web.</dd>
 
             <dt><a href="https://www.w3.org/2020/gpu/">GPU for the Web WG</a></dt>
@@ -327,7 +327,7 @@
             <dt><a href="https://www.w3.org/WoT/WG/">Web of Things WG</a> and <a href="https://www.w3.org/WoT/IG/">Web of Things IG</a></dt>
             <dd>The Web of Things Working Group and Interest Group discuss the architecture, the data model and related technologies for the Web of Things. Those specifications could be useful to model some of the features investigated by the Media and Entertainment Interest Group, e.g., for device integration.</dd>
 
-            <dt><a href="https://www.w3.org/WebPlatform/WG">Web Platform WG</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/webapps/">Web Applications WG</a></dt>
             <dd>The Web Platform Working Group develops the core HTML standard that specifies the media player of the web platform. The group also develops other interfaces that are particularly relevant for the media industry, such as the <code>KeyboardEvent</code> interface with dedicated keys and values for TV/media remote controls.</dd>
 
             <dt><a href="https://www.w3.org/2011/04/webrtc/">Web Real-Time Communications WG</a></dt>
@@ -638,7 +638,7 @@ groups are likely to be important: </p>
             to convey needs of the media industry across existing groups, for
             instance in the <a href="https://www.w3.org/html/wg/">HTML
             Media Extensions Working Group</a>, <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a>, and
-            <a href="https://www.w3.org/WebPlatform/WG">Web Platform Working
+            <a href="https://www.w3.org/groups/wg/webapps/">Web Applications Working
             Group</a>.
           </p>
 


### PR DESCRIPTION
 Web Platform WG is now Web Applications Working Group.
